### PR TITLE
feat: add jacoco

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'jacoco'
 
 android {
     signingConfigs {}
@@ -29,6 +30,9 @@ android {
     }
 
     buildTypes {
+        debug{
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -55,6 +59,26 @@ android {
         }
     }
 }
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "${project.buildDir}/intermediates/javac/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories.from(files([mainSrc]))
+    classDirectories.from(files([debugTree]))
+
+    executionData.from(fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ]))
+}
+
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,8 @@ android {
     }
 
     buildTypes {
-        debug{
+        debug {
+            debuggable true
             testCoverageEnabled true
         }
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.jacocoVersion = '0.8.4'
     repositories {
         google()
         mavenCentral()
@@ -13,6 +14,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This is for adding an example for running Espresso with Jacoco test coverage. To run locally

```logs
#push apps
adb install apps/jacoco/my-demo-app-android.apk
adb install apps/jacoco/my-demo-app-android-tests.apk

# Run with coverage
adb shell am instrument -w -e coverage true com.saucelabs.mydemoapp.android.test/androidx.test.runner.AndroidJUnitRunner
```

Then you will get the logs and at the end of the logs you will see something like this

```logs
Generated code coverage data to /data/user/0/com.saucelabs.mydemoapp.android/files/coverage.ec
```

~Challenge is that the content is not found on an emulator~

**Update:**
Content can be found on the device. You can `adb shell` into the device something like this

```logs
# used adb shell to find the file
adb shell                                                                                                               
beyond1:/ $ run-as com.saucelabs.mydemoapp.android                                                                                                                                                                      
beyond1:/data/data/com.saucelabs.mydemoapp.android $ cd files
beyond1:/data/data/com.saucelabs.mydemoapp.android/files $ ls
coverage.ec

# copy to the SD and pull the the file from the SD
beyond1:/data/data/com.saucelabs.mydemoapp.android/files $ cp coverage.ec /sdcard/      
beyond1:/data/data/com.saucelabs.mydemoapp.android/files $ exit
beyond1:/ $ exit

# pull the file from the device
adb pull /sdcard/coverage.ec                                                                                                         
/sdcard/coverage.ec: 1 file pulled, 0 skipped. 0.1 MB/s (10804 bytes in 0.095s)
``` 

