### PR TITLE
Add Sauce Visual example

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -26,7 +26,6 @@ suites:
       - name: "Samsung.*"
         platformVersion: "13"
     testOptions:
-      size: large
       visualCheck: $VISUAL_CHECK
 
 

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -25,6 +25,9 @@ suites:
         platformVersion: "14"
       - name: "Samsung.*"
         platformVersion: "13"
+    testOptions:
+      size: large
+      visualCheck: $VISUAL_CHECK
 
 
 # Controls what artifacts to fetch when the suite on Sauce Cloud has finished.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     //Libraries For Testing
-    androidTestImplementation 'com.saucelabs.visual:visual-espresso:0.0.1'
+    androidTestImplementation 'com.saucelabs.visual:visual-espresso:0.0.1-RC'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation("com.android.support.test.espresso:espresso-contrib:3.0.2")
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
+
+        buildConfigField "String", "SAUCE_USERNAME", getProperty("SAUCE_USERNAME", "\"\"")
+        buildConfigField "String", "SAUCE_ACCESS_KEY", getProperty("SAUCE_ACCESS_KEY", "\"\"")
     }
 
     testOptions {
@@ -61,6 +64,15 @@ android {
     }
 }
 
+String getProperty(String name, String defaultValue) {
+    if (!rootProject.file("./local.properties").exists()) {
+        return defaultValue
+    }
+    def properties = new Properties()
+    properties.load(rootProject.file("./local.properties").newDataInputStream())
+    return properties.containsKey(name) ? properties[name] : defaultValue
+}
+
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
 
     reports {
@@ -90,6 +102,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     //Libraries For Testing
+    androidTestImplementation 'com.saucelabs.visual:visual-espresso:0.0.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation("com.android.support.test.espresso:espresso-contrib:3.0.2")
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 
-        buildConfigField "String", "SAUCE_USERNAME", getProperty("SAUCE_USERNAME", "\"\"")
-        buildConfigField "String", "SAUCE_ACCESS_KEY", getProperty("SAUCE_ACCESS_KEY", "\"\"")
+        buildConfigField "String", "SAUCE_USERNAME", "\"${System.getenv('SAUCE_USERNAME')}\""
+        buildConfigField "String", "SAUCE_ACCESS_KEY", "\"${System.getenv('SAUCE_ACCESS_KEY')}\""
     }
 
     testOptions {
@@ -62,15 +62,6 @@ android {
             v2SigningEnabled true
         }
     }
-}
-
-String getProperty(String name, String defaultValue) {
-    if (!rootProject.file("./local.properties").exists()) {
-        return defaultValue
-    }
-    def properties = new Properties()
-    properties.load(rootProject.file("./local.properties").newDataInputStream())
-    return properties.containsKey(name) ? properties[name] : defaultValue
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {

--- a/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/LoginTest.java
+++ b/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/LoginTest.java
@@ -163,7 +163,6 @@ public class LoginTest extends BaseTest {
                 .perform(scroll)
                 .perform(click());
 
-        Espresso.pressBack();
         onView(withId(R.id.menuIV)).check(matches(isDisplayed()));
     }
 }

--- a/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
+++ b/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
@@ -71,6 +71,8 @@ public class VisualTest extends BaseTest {
         String name = TextUtils.isEmpty(visualCheck) ? "bod@example.com" : "visual@example.com";
         String pass = "10203040";
 
+        waitView(withId(R.id.menuRV));
+
         // enter a name
         onView(withId(R.id.nameET)).perform(typeText(name), closeSoftKeyboard());
         onView(withId(R.id.passwordET)).perform(typeText(pass), closeSoftKeyboard());

--- a/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
+++ b/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
@@ -7,7 +7,10 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withParentIndex;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.core.AllOf.allOf;
 
 import android.text.TextUtils;
 
@@ -23,6 +26,7 @@ import com.saucelabs.mydemoapp.android.BuildConfig;
 import com.saucelabs.mydemoapp.android.R;
 import com.saucelabs.mydemoapp.android.actions.NestingAwareScrollAction;
 import com.saucelabs.mydemoapp.android.actions.SideNavClickAction;
+import com.saucelabs.visual.VisualCheckOptions;
 import com.saucelabs.visual.VisualClient;
 import com.saucelabs.visual.junit.TestMetaInfoRule;
 
@@ -80,9 +84,24 @@ public class VisualTest extends BaseTest {
 
         waitView(withId(R.id.menuIV));
 
-        client.sauceVisualCheck("App Catalog");
+        client.sauceVisualCheck("App Catalog", VisualCheckOptions.builder()
+                .ignore( // Ignore any changes on the first image
+                        allOf(withParentIndex(0),  // Get the first element in ViewGroup (an image)
+                                withParent(allOf(
+                                        withParentIndex(0),  // Get the first element in RV (a ViewGroup)
+                                        withParent(withId(R.id.productRV)))))
+                )
+                .build());
 
         onView(withId(R.id.menuIV)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void captureOnlyAppCatalog() {
+        waitView(withId(R.id.menuIV));
+        client.sauceVisualCheck("Catalog Fragment", VisualCheckOptions.builder()
+                .clipElement(withId(R.id.scrollView))
+                .build());
     }
 
     @AfterClass

--- a/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
+++ b/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
@@ -1,0 +1,92 @@
+package com.saucelabs.mydemoapp.android.view.activities;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import android.text.TextUtils;
+
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.saucelabs.mydemoapp.android.BaseTest;
+import com.saucelabs.mydemoapp.android.BuildConfig;
+import com.saucelabs.mydemoapp.android.R;
+import com.saucelabs.mydemoapp.android.actions.NestingAwareScrollAction;
+import com.saucelabs.mydemoapp.android.actions.SideNavClickAction;
+import com.saucelabs.visual.VisualClient;
+import com.saucelabs.visual.junit.TestMetaInfoRule;
+
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class VisualTest extends BaseTest {
+
+    private final ViewAction scroll = new NestingAwareScrollAction();
+
+    @Rule
+    public ActivityScenarioRule<SplashActivity> activityRule = new ActivityScenarioRule<>(SplashActivity.class);
+
+    @Rule
+    public TestMetaInfoRule testMetaInfoRule = new TestMetaInfoRule();
+
+    static VisualClient client = VisualClient.builder(BuildConfig.SAUCE_USERNAME, BuildConfig.SAUCE_ACCESS_KEY)
+            .buildName("My Demo App")
+            .build();
+
+    @Test
+    public void checkAppCatalog() {
+
+        waitView(withId(R.id.menuIV));
+
+        client.sauceVisualCheck("Startup");
+
+        onView(withId(R.id.menuIV))
+                .perform(click());
+
+        waitView(withId(R.id.menuRV));
+
+        onView(withId(R.id.menuRV))
+                .perform(RecyclerViewActions.scrollToPosition(10))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(10, new SideNavClickAction()));
+
+        String visualCheck = InstrumentationRegistry.getArguments().getString("visualCheck", "");
+        String name = TextUtils.isEmpty(visualCheck) ? "bod@example.com" : "visual@example.com";
+        String pass = "10203040";
+
+        // enter a name
+        onView(withId(R.id.nameET)).perform(typeText(name), closeSoftKeyboard());
+        onView(withId(R.id.passwordET)).perform(typeText(pass), closeSoftKeyboard());
+
+        onView(withId(R.id.nameET)).check(matches(withText(name)));
+        onView(withId(R.id.passwordET)).check(matches(withText(pass)));
+
+        onView(withId(R.id.loginBtn))
+                .perform(scroll)
+                .perform(click());
+
+        waitView(withId(R.id.menuIV));
+
+        client.sauceVisualCheck("App Catalog");
+
+        onView(withId(R.id.menuIV)).check(matches(isDisplayed()));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        client.finish();
+    }
+}

--- a/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
+++ b/app/src/androidTest/java/com/saucelabs/mydemoapp/android/view/activities/VisualTest.java
@@ -26,11 +26,13 @@ import com.saucelabs.mydemoapp.android.BuildConfig;
 import com.saucelabs.mydemoapp.android.R;
 import com.saucelabs.mydemoapp.android.actions.NestingAwareScrollAction;
 import com.saucelabs.mydemoapp.android.actions.SideNavClickAction;
+import com.saucelabs.mydemoapp.android.utils.SingletonClass;
 import com.saucelabs.visual.VisualCheckOptions;
 import com.saucelabs.visual.VisualClient;
 import com.saucelabs.visual.junit.TestMetaInfoRule;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +52,12 @@ public class VisualTest extends BaseTest {
     static VisualClient client = VisualClient.builder(BuildConfig.SAUCE_USERNAME, BuildConfig.SAUCE_ACCESS_KEY)
             .buildName("My Demo App")
             .build();
+
+    @Before
+    public void removeLogin() {
+        SingletonClass.getInstance().isLogin = false;
+        SingletonClass.getInstance().hasVisualChanges = false;
+    }
 
     @Test
     public void checkAppCatalog() {

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ buildscript {
         mavenCentral()
         jcenter()
         maven { url "https://www.jitpack.io" }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/staging/"
+        }
     }
 
     dependencies {
@@ -25,6 +28,9 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://www.jitpack.io" }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/staging/"
+        }
     }
 }
 


### PR DESCRIPTION
This adds the Sauce Visual Espresso example to demo app. The reference to staging maven will be removed once 0.0.1 is released to main maven repository.